### PR TITLE
fix case sensitivity

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -89,7 +89,7 @@ def parse_args():
         dest="status",
         default="",
         help="Task status. One of: needsAction, completed.",
-        type=str.lower,
+        type=str,
     )
     parser.add_argument(
         "--user",


### PR DESCRIPTION
default str.lower argument type removes the capitalized characters but Enum class of TaskStatus is capitalized:
https://github.com/google/gtasks-md/blob/04640549ecd054b2f179558f75bad1e1f5a7cf2d/app/tasks.py#L22
```bash
$ PS C:\Windows> gtasks-md --status needsAction view
...
ValueError: 'needsaction' is not a valid TaskStatus
...
```
