### PR TITLE
Add build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __build__/
 
 /dist/
 /gtasks_md.egg-info/
+
+/build/


### PR DESCRIPTION
This ephemeral directory seems to be created by:

    pipx install .